### PR TITLE
Improve Todoist integration with priority support and webhook verification

### DIFF
--- a/app/providers/todoist.py
+++ b/app/providers/todoist.py
@@ -15,9 +15,15 @@ class TodoistAdapter(ProviderAdapter):
         })
 
     def create_task(self, task):
-        payload = {"content": task["title"], "description": task.get("description",""), "project_id": self.project_id}
+        payload = {
+            "content": task["title"],
+            "description": task.get("description", ""),
+            "project_id": self.project_id,
+        }
         if task.get("deadline"):
             payload["due_datetime"] = task["deadline"]
+        if task.get("priority"):
+            payload["priority"] = task["priority"]
         r = self.client.post(f"{TD_API}/tasks", json=payload)
         r.raise_for_status()
         return r.json()
@@ -45,6 +51,7 @@ class TodoistAdapter(ProviderAdapter):
             self.client.post(f"{TD_API}/tasks/{external_id}/close")
 
     def verify_webhook(self, headers, raw_body):
-        sig = headers.get("x-todoist-hmac-sha256","")
-        mac = hmac.new(self.webhook_secret.encode(), raw_body, hashlib.sha256).hexdigest()
-        return hmac.compare_digest(sig, mac)
+        sig = headers.get("x-todoist-hmac-sha256", "")
+        mac = hmac.new(self.webhook_secret.encode(), raw_body, hashlib.sha256).digest()
+        mac_b64 = base64.b64encode(mac).decode()
+        return hmac.compare_digest(sig, mac_b64)

--- a/tests/test_todoist_provider.py
+++ b/tests/test_todoist_provider.py
@@ -1,0 +1,43 @@
+import hmac
+import hashlib
+import base64
+from app.providers.todoist import TodoistAdapter
+
+class DummyResponse:
+    def __init__(self, json_data=None):
+        self._json = json_data or {}
+    def raise_for_status(self):
+        pass
+    def json(self):
+        return self._json
+
+class DummyClient:
+    def __init__(self):
+        self.last_request = None
+    def post(self, url, json):
+        self.last_request = {"url": url, "json": json}
+        return DummyResponse({"id": "1"})
+
+
+def test_create_task_includes_deadline_and_priority():
+    adapter = TodoistAdapter("token", "secret", "proj")
+    adapter.client = DummyClient()
+    task = {
+        "title": "Test",
+        "description": "Desc",
+        "deadline": "2025-01-01T00:00:00Z",
+        "priority": 4,
+    }
+    adapter.create_task(task)
+    sent = adapter.client.last_request["json"]
+    assert sent["due_datetime"] == "2025-01-01T00:00:00Z"
+    assert sent["priority"] == 4
+
+
+def test_verify_webhook_uses_base64():
+    secret = "secret"
+    body = b"{}"
+    adapter = TodoistAdapter("token", secret, "proj")
+    sig = base64.b64encode(hmac.new(secret.encode(), body, hashlib.sha256).digest()).decode()
+    assert adapter.verify_webhook({"x-todoist-hmac-sha256": sig}, body)
+    assert not adapter.verify_webhook({"x-todoist-hmac-sha256": "wrong"}, body)


### PR DESCRIPTION
## Summary
- Add priority field support when creating Todoist tasks
- Correct Todoist webhook verification to use base64 HMAC
- Add unit tests covering task creation payload and webhook signature validation

## Testing
- `make test` *(fails: docker: command not found)*
- `PYTHONPATH=$(pwd) pytest tests/test_todoist_provider.py`


------
https://chatgpt.com/codex/tasks/task_e_689b4f58d41c8333b7438014e089284d