### PR TITLE
Introduce Pydantic task models

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class TaskStatus(str, Enum):
+    """Enumeration of high-level task states."""
+    NEW = "new"
+    IN_PROGRESS = "in_progress"
+    DONE = "done"
+
+class Subtask(BaseModel):
+    """Representation of a simple subtask item."""
+    title: str
+    status: TaskStatus = TaskStatus.NEW
+    effort_hours: Optional[float] = None
+
+
+class TaskIntake(BaseModel):
+    """Incoming task information provided by external sources."""
+    title: str
+    description: Optional[str] = None
+    client: str = "unknown"
+    project: Optional[str] = None
+    deadline: Optional[datetime] = None
+    importance: int = 3
+    effort_hours: Optional[float] = None
+    labels: List[str] = Field(default_factory=list)
+    source: str = "api"
+    meta: dict[str, Any] = Field(default_factory=dict)
+
+class Task(BaseModel):
+    """Normalized task model used internally by the orchestrator."""
+    id: str
+    title: str
+    description: str = ""
+    client: str
+    project: Optional[str] = None
+    task_type: Optional[str] = None
+    deadline: Optional[datetime] = None
+    importance: int = 3
+    effort_hours: Optional[float] = None
+    labels: List[str] = Field(default_factory=list)
+    source: str = "api"
+    meta: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime
+    updated_at: datetime
+    idempotency_key: str
+    recent_progress: float = 0.0
+    client_sla_hours: Optional[float] = None
+    score: Optional[float] = None
+    checklist: List[str] = Field(default_factory=list)
+    subtasks: List[Subtask] = Field(default_factory=list)
+

--- a/app/utils/retry.py
+++ b/app/utils/retry.py
@@ -58,3 +58,4 @@ def default_httpx_retryable(statuses: Iterable[int] = (429, 500, 502, 503, 504))
         return False
 
     return _pred
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Core dependencies
 psycopg2-binary>=2.9.0
 fastapi>=0.100.0
+pydantic>=2.0.0
 uvicorn[standard]>=0.20.0
 httpx>=0.24.0
 


### PR DESCRIPTION
## Summary
- add Pydantic models for tasks, subtasks and intake data
- declare explicit pydantic dependency
- tidy retry utility file formatting

## Testing
- `PYTHONPATH=. pytest`
- `ruff check . | tail -n 20` *(fails: Found 78 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c05be36808333b8b7997f8f8ef288