### PR TITLE
refactor dataclasses default factories

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -8,7 +8,7 @@ import json
 import sqlite3
 from datetime import datetime, timezone, timedelta
 from typing import Dict, List, Optional, Tuple, Any
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, asdict, field
 from enum import Enum
 from pathlib import Path
 
@@ -47,15 +47,9 @@ class TaskContext:
     # Metadata
     effort_hours: float
     deadline: Optional[datetime] = None
-    created_at: datetime = None
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     assignee: Optional[str] = None
-    dependencies: List[str] = None
-    
-    def __post_init__(self):
-        if self.created_at is None:
-            self.created_at = datetime.now(timezone.utc)
-        if self.dependencies is None:
-            self.dependencies = []
+    dependencies: List[str] = field(default_factory=list)
 
 @dataclass 
 class OrchestrationDecision:

--- a/app/orchestrator_config.py
+++ b/app/orchestrator_config.py
@@ -7,7 +7,7 @@ import json
 import os
 from pathlib import Path
 from typing import Dict, Any, Optional
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, asdict, field
 import logging
 
 logger = logging.getLogger(__name__)
@@ -39,51 +39,35 @@ class StalenessConfig:
 class WIPConfig:
     """Work-in-Progress limits configuration"""
     default_limit: int = 3
-    limits_by_role: Dict[str, int] = None
+    limits_by_role: Dict[str, int] = field(
+        default_factory=lambda: {
+            'junior': 2,
+            'senior': 5,
+            'lead': 8,
+        }
+    )
     load_balance_threshold: float = 0.8
-    
-    def __post_init__(self):
-        if self.limits_by_role is None:
-            self.limits_by_role = {
-                'junior': 2,
-                'senior': 5,
-                'lead': 8
-            }
 
 @dataclass
 class ClientConfig:
     """Client-specific configuration"""
     default_daily_cap_hours: int = 8
-    client_caps: Dict[str, int] = None
+    client_caps: Dict[str, int] = field(default_factory=dict)
     fairness_lookback_hours: int = 168  # 1 week
-    
-    def __post_init__(self):
-        if self.client_caps is None:
-            self.client_caps = {}
 
 @dataclass
 class OrchestratorConfig:
     """Complete orchestrator configuration"""
     version: str = "1.0.0"
-    scoring_weights: ScoringWeights = None
-    staleness: StalenessConfig = None
-    wip: WIPConfig = None
-    client: ClientConfig = None
+    scoring_weights: ScoringWeights = field(default_factory=ScoringWeights)
+    staleness: StalenessConfig = field(default_factory=StalenessConfig)
+    wip: WIPConfig = field(default_factory=WIPConfig)
+    client: ClientConfig = field(default_factory=ClientConfig)
     
     # Advanced features
     enable_simulation_mode: bool = False
     enable_ml_predictions: bool = False
     debug_mode: bool = False
-    
-    def __post_init__(self):
-        if self.scoring_weights is None:
-            self.scoring_weights = ScoringWeights()
-        if self.staleness is None:
-            self.staleness = StalenessConfig()
-        if self.wip is None:
-            self.wip = WIPConfig()
-        if self.client is None:
-            self.client = ClientConfig()
     
     def validate(self) -> Dict[str, Any]:
         """Validate entire configuration"""

--- a/app/providers/adapter_framework.py
+++ b/app/providers/adapter_framework.py
@@ -9,7 +9,7 @@ import logging
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone, timedelta
 from typing import Dict, List, Optional, Any, Callable, AsyncIterator
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, asdict, field
 from enum import Enum
 
 class ProviderType(Enum):
@@ -57,10 +57,10 @@ class StandardTask:
     updated_at: Optional[datetime]
     deadline: Optional[datetime]
     effort_hours: float
-    labels: List[str]
-    subtasks: List[str]
-    checklist: List[str]
-    metadata: Dict[str, Any]
+    labels: List[str] = field(default_factory=list)
+    subtasks: List[str] = field(default_factory=list)
+    checklist: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
     
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for JSON serialization"""


### PR DESCRIPTION
## Summary
- use dataclass `field(default_factory=...)` for configuration models
- add safe defaults for task and provider models
- simplify TaskContext initialization

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689c05be36808333b8b7997f8f8ef288