### PR TITLE
docs: refresh tech badges and features

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,17 @@
 **AI-Powered Task Orchestration System**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
-[![FastAPI](https://img.shields.io/badge/FastAPI-0.104+-green.svg)](https://fastapi.tiangolo.com/)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
+[![FastAPI](https://img.shields.io/badge/FastAPI-0.116.1+-green.svg)](https://fastapi.tiangolo.com/)
+[![Pydantic](https://img.shields.io/badge/Pydantic-2.11.7+-purple.svg)](https://docs.pydantic.dev/)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-15+-blue.svg)](https://www.postgresql.org/)
 
 Project Archangel intelligently balances workload across multiple task management providers (ClickUp, Trello, Todoist) using sophisticated scoring algorithms, outbox patterns, and reliability mechanisms.
 
 ## 🌟 Features
 
+- **🚀 Modern Python Stack**: Powered by Python 3.12+, FastAPI 0.116.1+, and Pydantic 2.11.7+
+- **🧠 AI Provider Agnostic**: Extensible to state-of-the-art LLMs like OpenAI GPT-4o, Anthropic Claude 3.5, Meta Llama 3.1, and Google Gemini 1.5
 - **🎯 Intelligent Task Routing**: AI-powered scoring algorithm routes tasks to optimal providers
 - **⚖️ Workload Balancing**: Automatic load distribution across ClickUp, Trello, and Todoist
 - **🔄 Reliable Delivery**: Outbox pattern ensures exactly-once task delivery
@@ -22,7 +25,7 @@ Project Archangel intelligently balances workload across multiple task managemen
 
 ### Prerequisites
 
-- **Python 3.11+**
+- **Python 3.12+**
 - **Docker & Docker Compose**
 - **PostgreSQL 15+**
 - **Redis 7+**


### PR DESCRIPTION
## Summary
- highlight modern Python 3.12+, FastAPI 0.116.1+, and Pydantic 2.11.7+ in badges
- document support for cutting-edge LLM providers, adding Meta Llama 3.1 and Google Gemini 1.5
- update prerequisites to Python 3.12+

## Testing
- `pre-commit run --files README.md` *(fails: URLError: Tunnel connection failed: 403 Forbidden)*
- `pytest` *(fails: ImportError: cannot import name 'BaseAdapter')*


------
https://chatgpt.com/codex/tasks/task_e_68a399c223308333879ba68cb3144fae

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README badges to reflect Python 3.12+, FastAPI 0.116.1+, and added a Pydantic 2.11.7+ badge.
  * Revised prerequisites to require Python 3.12+.
  * Expanded Features section to highlight a modern Python stack and AI provider-agnostic support, including OpenAI GPT-4o, Anthropic Claude 3.5, Meta Llama 3.1, and Google Gemini 1.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->