### PR TITLE
Fix ClickUp adapter integration and webhook paths

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -69,6 +69,7 @@ def health():
     return {"ok": True}
 
 @app.post("/webhooks/clickup")
+@app.post("/api/webhooks/clickup")
 async def clickup_webhook(request: Request):
     adapter = clickup()
     raw = await request.body()
@@ -100,6 +101,7 @@ async def clickup_webhook(request: Request):
     return {"ok": True}
 
 @app.post("/webhooks/trello")
+@app.post("/api/webhooks/trello")
 async def trello_webhook(request: Request, x_trello_webhook: str = Header(None)):
     adapter = trello()
     raw = await request.body()
@@ -115,6 +117,7 @@ async def trello_webhook(request: Request, x_trello_webhook: str = Header(None))
     return {"ok": True}
 
 @app.post("/webhooks/todoist")
+@app.post("/api/webhooks/todoist")
 async def todoist_webhook(request: Request, x_todoist_hmac_sha256: str = Header(None)):
     adapter = todoist()
     raw = await request.body()

--- a/app/api_tasks.py
+++ b/app/api_tasks.py
@@ -24,7 +24,7 @@ from app.scoring import compute_score
 from app.triage_serena import triage_with_serena
 from app.audit import log_event
 from app.utils.outbox import OutboxManager
-from app.providers.base import BaseAdapter
+from app.providers.base import ProviderAdapter
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -111,7 +111,7 @@ class TaskStatsResponse(BaseModel):
     overdue_count: int
 
 # Utility functions
-def get_provider_adapter(provider_name: str) -> Optional[BaseAdapter]:
+def get_provider_adapter(provider_name: str) -> Optional[ProviderAdapter]:
     """Get provider adapter by name"""
     from app.api import ADAPTERS
     try:


### PR DESCRIPTION
## Summary
- replace deprecated BaseAdapter reference with ProviderAdapter in task API
- align ClickUp adapter retry config and add async request helper with priority & signature utilities
- expose webhook endpoints under `/api/webhooks/*` for ClickUp, Trello, and Todoist

## Testing
- `pytest tests/test_api_endpoints.py::TestWebhookEndpoints::test_clickup_webhook_endpoint -q`
- `pytest tests/test_load_performance.py`
- `DATABASE_URL=sqlite:///tmp.db pytest tests/test_integration_suite.py::TestProviderIntegrations -q`


------
https://chatgpt.com/codex/tasks/task_e_68a399e01d308333b758a11a024c8cb1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added alias endpoints: /api/webhooks/clickup, /api/webhooks/trello, and /api/webhooks/todoist.
  - Introduced ClickUp webhook signature verification for enhanced security.

- Improvements
  - ClickUp integration now supports asynchronous requests with unified error handling, better rate-limit handling, and idempotency for safer retries.
  - Enhanced priority mapping for ClickUp tasks to improve consistency and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->