### PR TITLE
Fix drag interference with bump and burn buttons

### DIFF
--- a/components/sortable-task-card.tsx
+++ b/components/sortable-task-card.tsx
@@ -40,14 +40,15 @@ export function SortableTaskCard({
     acc[key] = (e: any) => {
       // Check if the event target or any parent is a button or has data-no-drag
       const target = e.target as HTMLElement
-      if (
-        target.closest("button") ||
-        target.closest("[data-no-drag]") ||
-        target.tagName === "BUTTON" ||
-        target.hasAttribute("data-no-drag")
-      ) {
+      const isButton = target.closest("button") || target.tagName === "BUTTON"
+      const hasNoDrag = target.closest("[data-no-drag]") || target.hasAttribute("data-no-drag")
+
+      if (isButton || hasNoDrag) {
         console.log("[v0] Preventing drag on button/no-drag element")
-        e.preventDefault()
+        // Don't prevent default for buttons - let them handle clicks normally
+        if (!isButton) {
+          e.preventDefault()
+        }
         e.stopPropagation()
         return
       }

--- a/components/task-card.tsx
+++ b/components/task-card.tsx
@@ -134,6 +134,7 @@ export function TaskCard({ task, onClick, onBump, onBurn, onSendToReady, compact
   }
 
   const handleBurnClick = (e: React.MouseEvent) => {
+    e.preventDefault()
     e.stopPropagation()
     console.log("[v0] TaskCard handleBurnClick called for task:", task.id)
     if (isBurning) return
@@ -141,7 +142,7 @@ export function TaskCard({ task, onClick, onBump, onBurn, onSendToReady, compact
     setIsBurning(true)
 
     // Create ember burst
-    const cardElement = e.currentTarget.closest(".card") as HTMLElement
+    const cardElement = cardRef.current || (e.currentTarget.closest(".card") as HTMLElement)
     if (cardElement) {
       const emberCount = isUrgent ? 120 : 80
       createEmbersFrom(cardElement, emberCount, 1800)
@@ -160,6 +161,7 @@ export function TaskCard({ task, onClick, onBump, onBurn, onSendToReady, compact
   }
 
   const handleBumpClick = (e: React.MouseEvent) => {
+    e.preventDefault()
     e.stopPropagation()
     console.log("[v0] TaskCard handleBumpClick called for task:", task.id)
 
@@ -167,15 +169,31 @@ export function TaskCard({ task, onClick, onBump, onBurn, onSendToReady, compact
       setIsInteracted(true)
     }
 
-    if (cardRef.current && onBump) {
+    // Try to play sound (ignore if it fails)
+    if (boingSound) {
+      boingSound.currentTime = 0
+      boingSound.play().catch(() => {
+        console.log("[v0] Sound play failed - continuing without sound")
+      })
+    }
+
+    // Get the card element for animation
+    const cardElement = cardRef.current || (e.target as HTMLElement).closest('.card') as HTMLElement
+
+    if (cardElement && onBump) {
       console.log("[v0] Calling onBump with task ID and element")
-      onBump(task.id, cardRef.current)
+      onBump(task.id, cardElement)
     } else {
-      console.log("[v0] Missing cardRef or onBump handler")
+      console.log("[v0] Missing card element or onBump handler", {
+        hasCardRef: !!cardRef.current,
+        hasClosestCard: !!(e.target as HTMLElement).closest('.card'),
+        hasOnBump: !!onBump,
+      })
     }
   }
 
   const handleSendToReadyClick = (e: React.MouseEvent) => {
+    e.preventDefault()
     e.stopPropagation()
     if (cardRef.current && onSendToReady) {
       onSendToReady(task.id, cardRef.current)
@@ -398,7 +416,7 @@ export function TaskCard({ task, onClick, onBump, onBurn, onSendToReady, compact
 
                 {/* Action buttons */}
                 <motion.div
-                  className="flex items-center justify-end gap-1 pt-1"
+                  className="flex items-center justify-end gap-1 pt-1 pointer-events-auto"
                   initial={{ opacity: 0, y: 10 }}
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ delay: 0.5 }}
@@ -411,6 +429,7 @@ export function TaskCard({ task, onClick, onBump, onBurn, onSendToReady, compact
                           size="sm"
                           className="h-6 px-2 text-xs text-green-400/70 hover:text-green-300 hover:bg-green-500/10 transition-all duration-200"
                           onClick={handleSendToReadyClick}
+                          data-no-drag
                         >
                           <ArrowUp className="h-3 w-3 mr-1" />
                           Ready
@@ -423,6 +442,7 @@ export function TaskCard({ task, onClick, onBump, onBurn, onSendToReady, compact
                           className="h-6 px-2 text-xs text-red-400/70 hover:text-red-300 hover:bg-red-500/10 transition-all duration-200"
                           onClick={handleBurnClick}
                           disabled={isBurning}
+                          data-no-drag
                         >
                           <Trash2 className="h-3 w-3 mr-1" />
                           Burn
@@ -437,6 +457,7 @@ export function TaskCard({ task, onClick, onBump, onBurn, onSendToReady, compact
                           size="sm"
                           className="h-6 px-2 text-xs text-white/70 hover:text-white hover:bg-white/10 transition-all duration-200"
                           onClick={handleBumpClick}
+                          data-no-drag
                         >
                           <ArrowUp className="h-3 w-3 mr-1" />
                           Bump
@@ -449,6 +470,7 @@ export function TaskCard({ task, onClick, onBump, onBurn, onSendToReady, compact
                           className="h-6 px-2 text-xs text-red-400/70 hover:text-red-300 hover:bg-red-500/10 transition-all duration-200"
                           onClick={handleBurnClick}
                           disabled={isBurning}
+                          data-no-drag
                         >
                           <Trash2 className="h-3 w-3 mr-1" />
                           Burn

--- a/public/sounds/README.md
+++ b/public/sounds/README.md
@@ -1,0 +1,13 @@
+# Sound Files
+
+This directory contains sound files for the Project Archangel frontend.
+
+## Optional Files
+
+- `boing.mp3` - Sound played when bumping a task (optional)
+
+## Note
+
+Sound files are optional. The application will work without them, but audio feedback enhances the user experience.
+
+You can add your own `boing.mp3` file here for the bump sound effect.


### PR DESCRIPTION
## Summary
- Prevent drag listeners from cancelling button clicks
- Add safety checks and sound handling for bump and burn actions
- Document optional sound files for bump effect

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d59cf9288333898614f6122e20bb